### PR TITLE
fix watchOS deployment target to `4.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v10_14),
         .iOS(.v11),
         .tvOS(.v11),
-        .watchOS(.v2)
+        .watchOS(.v4)
     ],
     products: [
         .library(


### PR DESCRIPTION
Fixes: #50
